### PR TITLE
For sound speed at 1m/s for academic purposes

### DIFF
--- a/src/isimpa/IHM/AboutDialog.cpp
+++ b/src/isimpa/IHM/AboutDialog.cpp
@@ -76,7 +76,7 @@ bool AboutDialog::CreateAboutDialog(wxWindow *parent) {
 
 AboutDialog::AboutDialog()
         : aboutHtml(wxString::Format(
-        "<html><head> <meta charset=\"UTF-8\"></head><body><h2>I-SIMPA %i.%i.%i</h2><p><small>" + _("Built on %s") + "</small></p><p>" +
+        "<html><head> <meta charset=\"UTF-8\"></head><body><h2>I-SIMPA %i.%i.%i WARNING ACADEMIC (sound speed 1m/s)</h2><p><small>" + _("Built on %s") + "</small></p><p>" +
         _("An Open Source software for 3D sound propagation modelling.") + "</p>"
                 "<p>" + _("Classical Theory [%i.%i.%i]") + "</p><p>" + _("SPPS [%i.%i.%i]") +
         "</p><p>Read more on <a href=\"http://i-simpa.ifsttar.fr\">http://i-simpa.ifsttar.fr</a></p></body></html>",

--- a/src/lib_interface/data_manager/data_calculation/Celerite_du_son.cpp
+++ b/src/lib_interface/data_manager/data_calculation/Celerite_du_son.cpp
@@ -46,7 +46,7 @@ namespace CalculsGenerauxThermodynamique
 
 	double CCalculsGenerauxThermodynamique::c_son(double K)
 	{
-		double c = 343.2 * sqrt(K/Kref);
-		return c;
+		// Academic core, force value to 1 m/s
+		return 1;
 	}
 }

--- a/src/spps/sppsNantes.cpp
+++ b/src/spps/sppsNantes.cpp
@@ -244,7 +244,7 @@ int MainProcess(int argc, char* argv[])
 
 	using namespace std;
 
-	cout<<"SPPS version "<<SPPS_VERSION_MAJOR<<"."<<SPPS_VERSION_MINOR<<"."<<SPPS_VERSION_REVISION<<endl;
+	cout << "Warning SPPS ACADEMIC (sound speed 1m/s) version " << SPPS_VERSION_MAJOR << "." << SPPS_VERSION_MINOR << "." << SPPS_VERSION_REVISION << endl;
 	//**************************************************
 	//Initialisation
 	t_ToolBox applicationToolBox;


### PR DESCRIPTION
### Description

In this pull request, the following changes are made in the codebase:

1. In AboutDialog.cpp:
   - The title of the AboutDialog now includes a warning related to the academic nature of the software, specifying a sound speed of 1m/s.

2. In Celerite_du_son.cpp:
   - The calculation of sound speed is modified to force a constant value of 1 m/s in the academic core.

3. In sppsNantes.cpp:
   - Modified the console output message to include a warning about the academic nature of the software and specifying a sound speed of 1m/s.

These changes aim to provide clarity about the academic context and the specific sound speed value used in the calculations within the software.

If these changes are acceptable, please proceed with the code review.